### PR TITLE
Add a help-function get_user_by_nick as a patch

### DIFF
--- a/index/managers/usersmanger.py
+++ b/index/managers/usersmanger.py
@@ -7,6 +7,13 @@ from ..models.houses import House
 from .playerutils import Subject, Player, get_rank
 from .housesmanager import get_houses_name
 
+"""
+Used by the function ./views.py/profile
+TODO: Add a function to dox a user without a user object (@AmitTPB)
+"""
+def get_user_by_nick(nick):
+    return User.objects.filter(nick=nick).first()
+
 
 def get_all_players(state: str = "", house: str = "") -> list:
     if state and state not in USER_STATES:


### PR DESCRIPTION
Currently, there is no such way to dox a user without having a `User` instance. A situation for example is when only a nickname of a user is available.

This pull request adds a function that gets a user's nickname and returns the instance of the `User` class of the requested user.